### PR TITLE
Testflex

### DIFF
--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -1,10 +1,10 @@
 class Public::AddressesController < ApplicationController
-  
+
   before_action :authenticate_customer!
 
   def index
     @address = Address.new
-    @addresses = Address.all
+    @addresses = current_customer.addresses
   end
 
   def create

--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -1,5 +1,5 @@
 class Public::CustomersController < ApplicationController
-  
+
   before_action :authenticate_customer!
 
   def show
@@ -9,7 +9,7 @@ class Public::CustomersController < ApplicationController
   def edit
     @customer = current_customer
   end
-  
+
   def update
     @customer = current_customer
     @customer.update(customer_params)
@@ -21,7 +21,7 @@ class Public::CustomersController < ApplicationController
 
   def withdraw
     @customer = current_customer
-    @customer.update(is_deleted: false)
+    @customer.update(is_deleted: true)
     reset_session
     redirect_to root_path
   end

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -26,7 +26,7 @@
 
       <%= f.radio_button :address_option, 2 %>
       <%= f.label :address_option_2, "登録済み住所から選択" %><br>
-      <%= f.select :address_id, options_from_collection_for_select(Address.all, :id, :address_display) %><br>
+      <%= f.select :address_id, options_from_collection_for_select(current_customer.addresses.all, :id, :address_display) %><br>
 
       <%= f.radio_button :address_option, 3 %>
       <%= f.label :address_option_3, "新しいお届け先" %><br>


### PR DESCRIPTION
住所登録画面に他の会員の住所が表記される部分を修正
 注文情報入力画面の登録済み住所に他の会員の登録済み住所が表記される部分を修正
会員が退会完了後、管理者側でステータスが退会に変更するよう修正